### PR TITLE
deploy/kubernetes: fix secret.yml example file

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -36,8 +36,11 @@ metadata:
   name: packet-cloud-config
   namespace: kube-system
 stringData:
-  apiKey: "abc123abc123abc123"
-  projectID: "abc123abc123abc123"
+  cloud-sa.json: |
+    {
+    "apiKey": "abc123abc123abc123",
+    "projectID": "abc123abc123abc123"
+    }
 ```
 
 Then run:

--- a/deploy/kubernetes/secret.yml
+++ b/deploy/kubernetes/secret.yml
@@ -4,5 +4,8 @@ metadata:
   name: packet-cloud-config
   namespace: kube-system
 stringData:
-  apiKey: "packet auth token"
-  projectID: "packet project id"
+  cloud-sa.json: |
+    {
+    "apiKey": "packet auth token",
+    "projectID": "packet project id"
+    }


### PR DESCRIPTION
The controller expects the contents of the secret to be mounted at
`--config=/etc/cloud-sa/cloud-sa.json`, but the provided example secret
doesn't result in a file `cloud-sa.json`. Change it accordingly.