### PR TITLE
Avoid nil pointer deref when config parsing fails

### DIFF
--- a/cmd/csi-packet-driver/main.go
+++ b/cmd/csi-packet-driver/main.go
@@ -76,6 +76,10 @@ func main() {
 }
 
 func handle() {
-	d, _ := driver.NewPacketDriver(endpoint, nodeID, providerConfig)
+	d, err := driver.NewPacketDriver(endpoint, nodeID, providerConfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get packet driver: %v\n", err)
+		os.Exit(1)
+	}
 	d.Run()
 }


### PR DESCRIPTION
`NewPacketDriver` is currently not checked for an error and we run into
a nil pointer dereference if for example the configuration file couldn't
be found. Check for an error before moving along.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x846c8b]

goroutine 1 [running]:
github.com/packethost/csi-packet/pkg/driver.(*PacketDriver).Run(0x0)
        /home/schu/code/go/src/github.com/packethost/csi-packet/pkg/driver/driver.go:51 +0x7b
main.handle()
        /home/schu/code/go/src/github.com/packethost/csi-packet/cmd/csi-packet-driver/main.go:80 +0x77
main.main.func1(0xc0000aaf00, 0xc00007de90, 0x0, 0x3)
        /home/schu/code/go/src/github.com/packethost/csi-packet/cmd/csi-packet-driver/main.go:55 +0x20
github.com/packethost/csi-packet/vendor/github.com/spf13/cobra.(*Command).execute(0xc0000aaf00, 0xc00001e0d0, 0x3, 0x3, 0xc0000aaf00, 0xc00001e0d0)
        /home/schu/code/go/src/github.com/packethost/csi-packet/vendor/github.com/spf13/cobra/command.go:760 +0x2cc
github.com/packethost/csi-packet/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0000aaf00, 0x0, 0x9ba984, 0x1c)
        /home/schu/code/go/src/github.com/packethost/csi-packet/vendor/github.com/spf13/cobra/command.go:846 +0x2fd
github.com/packethost/csi-packet/vendor/github.com/spf13/cobra.(*Command).Execute(0xc0000aaf00, 0xc00001e0d0, 0x3)
        /home/schu/code/go/src/github.com/packethost/csi-packet/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
        /home/schu/code/go/src/github.com/packethost/csi-packet/cmd/csi-packet-driver/main.go:70 +0x28c
```