### PR TITLE
Enable usage of env vars to set API token and project ID

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -76,7 +76,23 @@ You can run the binary with `--help` to get command-line options. Important opti
 * `--endpoint=<path>` : (required) path to the kubelet registration socket. According to the spec, this should be `/var/lib/kubelet/plugins/<unique_provider_name>/csi.sock`. Thus we **strongly** recommend you mount it at `/var/lib/kubelet/plugins/net.packet.csi/csi.sock`. The deployment files in this repository assume that path.
 * `--nodeid=<name>` : (required) name of the node as understood by the kubernetes cluster. Normally retrieved via the Kubernetes [downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/) as `spec.nodeName`
 * `--v=<level>` : (optional) verbosity level per [logrus](https://github.com/sirupsen/logrus)
-* `--config=<path>` : (optional) path to config file, in json format, that contains the packet API key and project ID as keys `apiKey` and `projectID` respectively. This file is _required_, unless the environment variables `PACKET_API_KEY` and `PACKET_PROJECT_ID` are set.
+* `--config=<path>` : (optional) path to config file, in json format, that contains the Packet configuration information as set below.
+
+### Config File Format
+
+The configuration file passed to `--config` must be a json file, and should contain the following keys:
+
+* `apiKey` : packet API key to use
+* `projectID` : packet project ID
+* `facilityID` : packet facility ID
+
+### Environment Variables
+
+In addition to passing information via the config file, you can set it in environment variables. Environment variables _always_ override any setting in the config file. The variables are:
+
+* `PACKET_API_KEY`
+* `PACKET_PROJECT_ID`
+* `PACKET_FACILITY_ID`
 
 ## Running the csi-sanity tests
 [csi-sanity](https://github.com/kubernetes-csi/csi-test/tree/master/cmd/csi-sanity) is a set of integration tests that can be run on a host where a csi-plugin is running.

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1,9 +1,6 @@
 package driver
 
 import (
-	"encoding/json"
-	"io/ioutil"
-
 	"github.com/packethost/csi-packet/pkg/packet"
 	log "github.com/sirupsen/logrus"
 )
@@ -18,20 +15,7 @@ type PacketDriver struct {
 }
 
 // NewPacketDriver create a new PacketDriver
-func NewPacketDriver(endpoint, nodeID, configurationPath string) (*PacketDriver, error) {
-
-	var config packet.Config
-	if configurationPath != "" {
-		configBytes, err := ioutil.ReadFile(configurationPath)
-		if err != nil {
-			return nil, err
-		}
-		err = json.Unmarshal(configBytes, &config)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+func NewPacketDriver(endpoint, nodeID string, config packet.Config) (*PacketDriver, error) {
 	return &PacketDriver{
 		// name https://github.com/container-storage-interface/spec/blob/master/spec.md#getplugininfo
 		name:     "net.packet.csi", // this could be configurable, but must match a plugin directory name for kubelet to use


### PR DESCRIPTION
This PR does the following:

* Enable overriding settings from the config file (or not using it at all) via env vars
* Documents the environment variables
* Documents the format of the config file