### PR TITLE
return from CreateVolume only when it is ready, or fail if not

### DIFF
--- a/pkg/packet/volume.go
+++ b/pkg/packet/volume.go
@@ -66,3 +66,8 @@ func ReadDescription(serialized string) (VolumeDescription, error) {
 	err := json.Unmarshal([]byte(serialized), &desc)
 	return desc, err
 }
+
+// VolumeReady determine if a volume is in the ready state after being created
+func VolumeReady(volume *packngo.Volume) bool {
+	return volume != nil && volume.State == "active"
+}


### PR DESCRIPTION
When CSI calls `CreateVolume()`, it expects it to return only when the volume actually is provisioned and ready. However, packet's call to provision a volume only queues it up. You need to check if it is ready, otherwise immediately attaching it can cause issues.

This adds a check. If the volume is not in state `"active"` immediately upon return from create, it waits up to 10 seconds, checking every second, for it to become active.