### PR TITLE
Switch to unix syscall for unmount and handle already unmounted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/net v0.0.0-20190313220215-9f648a60d977
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20190312061237-fead79001313
 	google.golang.org/genproto v0.0.0-20180427144745-86e600f69ee4 // indirect
 	google.golang.org/grpc v1.12.0
 )

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/sys/unix"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -32,12 +34,12 @@ func bindmountFs(src, target string) error {
 }
 
 func unmountFs(path string) error {
-	args := []string{path}
-	_, err := execCommand("umount", args...)
-	// if err != nil {
-	// 	execCommand("rmdir", args...)
-	// }
-	return err
+	err := unix.Unmount(path, 0)
+	// we are willing to pass on a directory that is not mounted any more
+	if err != nil && err != unix.EINVAL {
+		return err
+	}
+	return nil
 }
 
 func mountMappedDevice(device, target string) error {


### PR DESCRIPTION
Prior versions used `execCommand("umount", ...)` to unmount a directory. Besides the inefficiency, this creates a problem that we don't actually know _why_ the unmount failed. Most errors we want to catch and report. But if the directory isn't a mount point (e.g. it already was unmounted), then we want to just move on. `unmount /foo` doesn't _really_ mean "unmount /foo", as far as we are concerned; it means, "make sure /foo isn't a mounted place." We care about final state, not the process. 

Unfortunately, the `umount` command does not have a standard exit code defined that can be used to see why it failed. However, the `umount(2)` syscall _does_ (defined in POSIX). We switch to the syscall, and all is good.