### PR TITLE
Add initialization code

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -11,13 +11,14 @@ var (
 
 // PacketDriver driver for packet cloud
 type PacketDriver struct {
-	name     string
-	nodeID   string
-	endpoint string
-	config   packet.Config
-	Logger   *log.Entry
-	Attacher Attacher
-	Mounter  Mounter
+	name        string
+	nodeID      string
+	endpoint    string
+	config      packet.Config
+	Logger      *log.Entry
+	Attacher    Attacher
+	Mounter     Mounter
+	Initializer Initializer
 }
 
 // NewPacketDriver create a new PacketDriver
@@ -30,8 +31,9 @@ func NewPacketDriver(endpoint, nodeID string, config packet.Config) (*PacketDriv
 		config:   config,
 		Logger:   log.WithFields(log.Fields{"node": nodeID, "endpoint": endpoint}),
 		// default attacher and mounter
-		Attacher: &AttacherImpl{},
-		Mounter:  &MounterImpl{},
+		Attacher:    &AttacherImpl{},
+		Mounter:     &MounterImpl{},
+		Initializer: &InitializerImpl{},
 	}, nil
 }
 

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -78,6 +78,7 @@ func TestPacketDriver(t *testing.T) {
 			bindmounts:  map[string]string{},
 			blockmounts: map[string]string{},
 		},
+		Initializer: &InitializerMock{},
 	}
 	defer driver.Stop()
 
@@ -439,4 +440,11 @@ func (m *MounterMock) GetMappedDevice(device string) (BlockInfo, error) {
 		UUID:       uuid.New().String(),
 		Mountpoint: "/mnt/foo",
 	}, nil
+}
+
+type InitializerMock struct {
+}
+
+func (i *InitializerMock) NodeInit(initiatorName string) error {
+	return nil
 }

--- a/pkg/driver/initializer.go
+++ b/pkg/driver/initializer.go
@@ -1,0 +1,99 @@
+package driver
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+const (
+	initiatorNameFile = "/etc/iscsi/initiatorname.iscsi"
+	mpathConfigFile   = "/etc/multipath.conf"
+	mpathConfig       = `
+defaults {
+       polling_interval       3
+       fast_io_fail_tmo 5
+       path_selector              "round-robin 0"
+       rr_min_io                    100
+       rr_weight                    priorities
+       failback                    immediate
+       no_path_retry              queue
+       user_friendly_names     yes
+}
+blacklist {
+         devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+         devnode "^hd[a-z][[0-9]*]"
+         devnode "^vd[a-z]"
+         devnode "^cciss!c[0-9]d[0-9]*[p[0-9]*]"
+         device {
+               vendor  "Micron"
+               product ".*"
+         }
+         device {
+               vendor  "Intel"
+               product ".*"
+         }
+         device {
+               vendor  "DELL"
+               product ".*"
+         }
+}
+devices {
+        device {
+                vendor "DATERA"
+                product "IBLOCK"
+                path_grouping_policy group_by_prio
+                path_checker tur
+                #checker_timer 5
+                #prio_callout "/sbin/mpath_prio_alua /dev/%n"
+                hardware_handler "1 alua"
+        }
+}
+`
+)
+
+type Initializer interface {
+	NodeInit(string) error
+}
+
+type InitializerImpl struct {
+}
+
+// NodeInit does all node initialization necessary for iscsi to be configured correctly
+func (n *InitializerImpl) NodeInit(initiatorName string) error {
+	if err := n.SetIscsiInitiator(initiatorName); err != nil {
+		return err
+	}
+	if err := n.ConfigureMultipath(); err != nil {
+		return err
+	}
+	if err := n.RestartServices(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetIscsiInitiator sets the name of the iscsi initiator
+func (n *InitializerImpl) SetIscsiInitiator(initiatorName string) error {
+	// get the name of our initiator
+	// update the file
+	contents := []byte(fmt.Sprintf("InitiatorName=%s\n", initiatorName))
+	err := ioutil.WriteFile(initiatorNameFile, contents, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *InitializerImpl) ConfigureMultipath() error {
+	contents := []byte(mpathConfig)
+	err := ioutil.WriteFile(mpathConfigFile, contents, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RestartServices should restart services, but we have no way to do that yet
+func (n *InitializerImpl) RestartServices() error {
+	return nil
+}

--- a/pkg/packet/utilities.go
+++ b/pkg/packet/utilities.go
@@ -70,6 +70,16 @@ func (m *MetadataDriver) GetFacilityCodeMetadata() (string, error) {
 	return device.Facility, nil
 }
 
+// GetInitiator get the initiator name for iscsi
+func (m *MetadataDriver) GetInitiator() (string, error) {
+	device, err := m.getMetadata()
+	if err != nil {
+		return "", err
+	}
+
+	return device.IQN, nil
+}
+
 // use this when packngo serialization is fixed
 // GetVolumeMetadata gets the volume metadata for a named volume
 func (m *MetadataDriver) packngoGetPacketVolumeMetadata(volumeName string) (metadata.VolumeInfo, error) {


### PR DESCRIPTION
One of the issues we have had is that the iscsid initiator name and the multipath config are not set correctly. This fixes that by ensuring that when the packet-driver for CSI on the node side starts up, it sets the config files correctly.

The problem is that it does _not_ restart `multipathd` and `iscsid`, which are required.

Thus, this remains a WIP, and should not be merged until `[WIP]` is removed, i.e. when we figure it out.

