### PR TITLE
Add simple target to makefile to report current version and git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,19 @@ ifndef PKG_LIST
 	$(eval PKG_LIST := $(shell $(BUILD_CMD) go list ./... | grep -v vendor))
 endif
 
-.PHONY: fmt-check lint test vet golint
+.PHONY: fmt-check lint test vet golint tag version
 
 $(DIST_DIR):
 	mkdir -p $@
+
+## report the git tag that would be used for the images
+tag:
+	@echo $(GIT_VERSION)
+
+## report the version that would be put in the binary
+version:
+	@echo $(VERSION)
+
 
 ## Check the file format
 fmt-check: 


### PR DESCRIPTION
Simple utility so you can do `make tag` to see what the docker image tag would be, and `make version` so you can see what version will be injected in the image.