### PR TITLE
Update StatefulSet to apps/v1

### DIFF
--- a/deploy/kubernetes/controller.yaml
+++ b/deploy/kubernetes/controller.yaml
@@ -14,7 +14,7 @@ spec:
 ---
 
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-packet-controller
   namespace: kube-system


### PR DESCRIPTION
It was as `apps/v1beta1`, while `StatefulSet` has been `apps/v1` since at least kubernetes 1.10. It was deprecated for a while, and `apps/v1beta1` won't even work on k8s 1.16.

