### PR TITLE
Update release tag for manifests

### DIFF
--- a/deploy/kubernetes/controller.yaml
+++ b/deploy/kubernetes/controller.yaml
@@ -62,7 +62,7 @@ spec:
               mountPath: /csi
         - name: packet-driver
           imagePullPolicy: Always
-          image: docker.io/packethost/csi-packet:196a346
+          image: docker.io/packethost/csi-packet:v1.0.0
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"

--- a/deploy/kubernetes/node.yaml
+++ b/deploy/kubernetes/node.yaml
@@ -40,7 +40,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: Always
-          image: docker.io/packethost/csi-packet:196a346
+          image: docker.io/packethost/csi-packet:v1.0.0
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"

--- a/deploy/kubernetes/node_controller_sanity_test.yaml
+++ b/deploy/kubernetes/node_controller_sanity_test.yaml
@@ -36,7 +36,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: Always
-          image: docker.io/packethost/csi-packet:196a346
+          image: docker.io/packethost/csi-packet:v1.0.0
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"


### PR DESCRIPTION
Officially change the deployment manifests to tags `v1.0.0`. Once this is in, we can push a release tag. Last PR before first official version. Huzzah!