### PR TITLE
register for cross-builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,18 @@ steps:
   - apk --update add make git
   - make ci
 
-## git tagged and latest images
+## register qemu for cross building
+
+- name: qemu-register
+  image: plugins/docker
+  commands:
+  - make register ARCH=all
+  when:
+    branch:
+    - master
+    event: push
+
+## publish git tagged and latest images
 
 - name: publish-amd64
   pull: always


### PR DESCRIPTION
Builds for `arm64` are failing in drone, because of the lack of qemu emulation support. This _should_ fix it.

E.g. see the failure [here](https://cloud.drone.io/packethost/csi-packet/14/1/4)

