### PR TITLE
Allow up to 5 seconds for detach before attaching anew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ endif
 
 ## Lint the files
 lint: pkgs golint golangci-lint
-	@$(BUILD_CMD) $(LINTER) run --disable-all --enable=golint pkg/... cmd/
+	@$(BUILD_CMD) $(LINTER) run --disable-all --enable=golint pkg/... cmd/...
 
 ## Run unittests
 test: pkgs

--- a/pkg/packet/errors.go
+++ b/pkg/packet/errors.go
@@ -1,0 +1,41 @@
+package packet
+
+import "fmt"
+
+// WrongDeviceAttachmentError error type that volume is attached to a different device
+type WrongDeviceAttachmentError struct {
+	deviceID string
+}
+
+// Error return the error string
+func (w WrongDeviceAttachmentError) Error() string {
+	return fmt.Sprintf("Attached to wrong device: %s", w.deviceID)
+}
+
+// IsWrongDeviceAttachment check if this error is a wrong device attachment
+func IsWrongDeviceAttachment(err error) bool {
+	switch err.(type) {
+	case *WrongDeviceAttachmentError:
+		return true
+	}
+	return false
+}
+
+// TooManyDevicesAttachedError error type that volume is attached to multiple devices
+type TooManyDevicesAttachedError struct {
+	deviceIDs []string
+}
+
+// Error return the error string
+func (t TooManyDevicesAttachedError) Error() string {
+	return fmt.Sprintf("Attached to multiple devices: %v", t.deviceIDs)
+}
+
+// IsTooManyDevicesAttached check if this error is a too many devices attached error
+func IsTooManyDevicesAttached(err error) bool {
+	switch err.(type) {
+	case *TooManyDevicesAttachedError:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Currently, nothing in the Packet API prevents a volume from being attached to 2 hosts at the same time. Although we do a detach first, it is possible for it to get confused and attach to a second host while the first one is connected, or for the unpublish to fail silently and it gets attached to a new one.

This does the following:

* prevent attachment to a new node if the first node still is attached
* allow a timeout for the above of 5 retries in 5 seconds, so it will retry for 5 seconds and only  then give up
* prevent attachment if the volume already is attached to more than one node