### PR TITLE
Add fallback for detach timing

### DIFF
--- a/pkg/packet/errors.go
+++ b/pkg/packet/errors.go
@@ -39,3 +39,20 @@ func IsTooManyDevicesAttached(err error) bool {
 	}
 	return false
 }
+
+// DeviceStillAttachedError error type that volume still is attached to a device
+type DeviceStillAttachedError struct{}
+
+// Error return the error string
+func (d DeviceStillAttachedError) Error() string {
+	return "Cannot delete when still attached"
+}
+
+// IsDeviceStillAttached check if this error is a device still attached error
+func IsDeviceStillAttached(err error) bool {
+	switch err.(type) {
+	case *DeviceStillAttachedError:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
We have an open issue wherein it can take a few seconds for the storage and/or Packet API to register that an iscsi session has been logged out. This means that the host detach returns an error to CSI, and it all fails.

This adds a fallback/retry of up to 5 seconds before giving up.