### PR TITLE
update to newer version of csi-provisioner and csi-attacher

### DIFF
--- a/deploy/kubernetes/controller.yaml
+++ b/deploy/kubernetes/controller.yaml
@@ -33,14 +33,13 @@ spec:
       labels:
         app: csi-packet-pd-driver
     spec:
-      serviceAccount: csi-controller-sa
+      serviceAccountName: csi-controller-sa
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: IfNotPresent
-          image: quay.io/k8scsi/csi-provisioner:v1.0.1
+          image: quay.io/k8scsi/csi-provisioner:v1.5.0
           args:
             - "--v=5"
-            - "--provisioner=csi.packet.net"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
@@ -50,7 +49,7 @@ spec:
               mountPath: /csi
         - name: csi-attacher
           imagePullPolicy: IfNotPresent
-          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          image: quay.io/k8scsi/csi-attacher:v2.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/setup.yaml
+++ b/deploy/kubernetes/setup.yaml
@@ -1,21 +1,21 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: csi-packet-standard
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: csi.packet.net
+provisioner: net.packet.csi
 parameters:
   plan: standard
 volumeBindingMode: Immediate
 
 ---
 
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: csi-packet-performance
-provisioner: csi.packet.net
+provisioner: net.packet.csi
 parameters:
   plan: performance
 volumeBindingMode: Immediate


### PR DESCRIPTION
due to incompatibility with kubernetes 1.20 csi-provisioner and
csi-attacher needed to be upgraded. more info in issue #99

fixes #99